### PR TITLE
Upgrade for 2025

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,10 +11,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
       - name: Maven verify
         run: ./mvnw -B -ntp verify -f pom.xml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,10 +15,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
           server-id: github
           settings-path: ${{ github.workspace }}

--- a/pom.xml
+++ b/pom.xml
@@ -14,31 +14,37 @@
   <properties>
     <!-- project settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>21</java.version>
+    <surefireArgLine/>
+    <failsafeArgLine/>
 
     <!-- plugins -->
-    <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
-    <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-    <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
-    <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
-    <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-project-info-reports-plugin.version>3.2.2</maven-project-info-reports-plugin.version>
-    <maven-release-plugin.version>3.0.0</maven-release-plugin.version>
+    <findsecbugs-plugin.version>1.14.0</findsecbugs-plugin.version>
+    <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
+    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
+    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+    <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
+    <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+    <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-    <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <spotbugs-maven-plugin.version>4.7.3.4</spotbugs-maven-plugin.version>
-    <spotless-maven-plugin.version>2.24.1</spotless-maven-plugin.version>
-    <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
+    <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
+    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+    <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
+    <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
+    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
 
     <!-- dependencies -->
-    <assertj-core.version>3.24.2</assertj-core.version>
-    <junit-bom.version>5.9.3</junit-bom.version>
-    <spotbugs.version>4.7.3</spotbugs.version>
+    <assertj-core.version>3.27.3</assertj-core.version>
+    <junit-bom.version>5.13.1</junit-bom.version>
+    <spotbugs.version>4.9.3</spotbugs.version>
+    <mockito-core.version>5.18.0</mockito-core.version>
   </properties>
 
   <dependencyManagement>
@@ -55,6 +61,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito-core.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -69,6 +80,11 @@
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven-assembly-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
@@ -89,6 +105,10 @@
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven-enforcer-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
@@ -117,6 +137,9 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <argLine>@{surefireArgLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
@@ -155,7 +178,7 @@
             <arg>-Xlint</arg>
           </compilerArgs>
           <failOnWarning>true</failOnWarning>
-          <release>17</release>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>
@@ -169,7 +192,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[17,)</version>
+                  <version>[${java.version},)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -252,7 +275,8 @@
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
           <ignoredVersions>
-            <ignoredVersion>.+-M.</ignoredVersion>
+            <ignoredVersion>.+-M.*</ignoredVersion>
+            <ignoredVersion>.+-beta.*</ignoredVersion>
           </ignoredVersions>
         </configuration>
       </plugin>
@@ -266,4 +290,70 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>integration-tests</id>
+      <activation>
+        <file>
+          <exists>src/integration</exists>
+        </file>
+      </activation>
+
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/integration/resources</directory>
+          </testResource>
+        </testResources>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>properties</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-test-source</id>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <phase>generate-test-sources</phase>
+                <configuration>
+                  <sources>
+                    <source>src/integration/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <argLine>@{failsafeArgLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+              <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Project has been dormant for too long. The following has been done for upgrades:
 * Use Java 21 as default
 * Add Mockito as dependency
 * Update all property versions
 * Add failsafe configuration
 * Ignore properties with beta releases

Note that failsafe is configured to only be active if the directory "src/integration" exist rather than the normal setup.